### PR TITLE
Don't try to lookup products if we have no product id

### DIFF
--- a/app/code/community/Segment/Analytics/Model/Controller/Viewedproduct.php
+++ b/app/code/community/Segment/Analytics/Model/Controller/Viewedproduct.php
@@ -7,7 +7,7 @@ class Segment_Analytics_Model_Controller_Viewedproduct extends Segment_Analytics
         // $product = Mage::getModel('catalog/product_api')->info($params['id']);
 
         if (!array_key_exists('id', $params) || is_null($params['id'])) {
-            return $block;
+            return;
         }
         $product   = Mage::helper('segment_analytics')
         ->getNormalizedProductInformation($params['id']);   

--- a/app/code/community/Segment/Analytics/Model/Controller/Viewedproduct.php
+++ b/app/code/community/Segment/Analytics/Model/Controller/Viewedproduct.php
@@ -7,7 +7,7 @@ class Segment_Analytics_Model_Controller_Viewedproduct extends Segment_Analytics
         // $product = Mage::getModel('catalog/product_api')->info($params['id']);
 
         if (!array_key_exists('id', $params) || is_null($params['id'])) {
-            return;
+            return $block;
         }
         $product   = Mage::helper('segment_analytics')
         ->getNormalizedProductInformation($params['id']);   

--- a/app/code/community/Segment/Analytics/Model/Controller/Viewedproduct.php
+++ b/app/code/community/Segment/Analytics/Model/Controller/Viewedproduct.php
@@ -6,6 +6,9 @@ class Segment_Analytics_Model_Controller_Viewedproduct extends Segment_Analytics
         $params = $block->getParams();
         // $product = Mage::getModel('catalog/product_api')->info($params['id']);
 
+        if (!array_key_exists('id', $params) || is_null($params['id'])) {
+            return;
+        }
         $product   = Mage::helper('segment_analytics')
         ->getNormalizedProductInformation($params['id']);   
                 


### PR DESCRIPTION
Viewproduct.php

Magento was storing state that was being passed to Viewedproduct.php
that did not match said script's expected format. These are now being
ignored.
