### PR TITLE
Return Category Names Rather Than IDs

### DIFF
--- a/app/code/community/Segment/Analytics/Model/Controller/Viewedproduct.php
+++ b/app/code/community/Segment/Analytics/Model/Controller/Viewedproduct.php
@@ -11,6 +11,10 @@ class Segment_Analytics_Model_Controller_Viewedproduct extends Segment_Analytics
         }
         $product   = Mage::helper('segment_analytics')
         ->getNormalizedProductInformation($params['id']);   
+        // Replace the category ids with their names.
+        $categories  = Mage::helper('segment_analytics')
+        ->getCategoryNamesFromIds($product['categories']);   
+        $product['categories'] = $categories;
                 
         $block->setParams($product);
         return $block;


### PR DESCRIPTION
Viewedproduct.php

For "Viewed Product" events, return category names rather than category ids.
